### PR TITLE
Ignore subdirectories in input directory

### DIFF
--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -117,6 +117,10 @@ def prepare_input_files(input_dir, output_dir):
     part_num = 0
     total_size = 0
     for inpath in sorted(input_dir.glob('*')):
+        # Skip subdirectories
+        if inpath.is_dir():
+            continue
+
         assert inpath.is_file()
 
         # Compute output filenames


### PR DESCRIPTION
(To support HTML dataset changes to P5)

We want Madoop to ignore subdirectories in the input directory (and not throw an error).

Note to @awdeorio: We're gonna need a new release before P5 launches!