### PR TITLE
Optimizations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+concurrency = thread,multiprocessing
+parallel = true

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ build/
 /.tox/
 /.coverage*
 *,cover
+# Make an exception for .coveragerc, which should be checked into version control.
+!.coveragerc
 
 # Text editors and IDEs
 *~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ graft madoop/example
 
 # Avoid dev and and binary files
 exclude tox.ini
+exclude .coveragerc
 exclude .editorconfig
 global-exclude *.pyc
 global-exclude __pycache__

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -17,7 +17,7 @@ from .exceptions import MadoopError
 
 
 # Large input files are automatically split
-MAX_INPUT_SPLIT_SIZE = 2**20  # 1 MB
+MAX_INPUT_SPLIT_SIZE = 10 * 1024 * 1024  # 10 MB
 
 # The number of reducers is dynamically determined by the number of unique keys
 # but will not be more than num_reducers

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -266,6 +266,25 @@ def partition_keys(
             output_keys_stats[outpath].add(key)
 
 
+def log_input_key_stats(input_keys_stats, input_dir):
+    """Log input key stats."""
+    all_input_keys = set()
+    for inpath, keys in sorted(input_keys_stats.items()):
+        all_input_keys.update(keys)
+        LOGGER.debug("%s unique_keys=%s", last_two(inpath), len(keys))
+    LOGGER.debug("%s all_unique_keys=%s", input_dir.name, len(all_input_keys))
+
+
+def log_output_key_stats(output_keys_stats, output_dir):
+    """Log output keyspace stats."""
+    all_output_keys = set()
+    for outpath, keys in sorted(output_keys_stats.items()):
+        all_output_keys.update(keys)
+        LOGGER.debug("%s unique_keys=%s", last_two(outpath), len(keys))
+    LOGGER.debug("%s all_unique_keys=%s", output_dir.name,
+                 len(all_output_keys))
+
+
 def group_stage(input_dir, output_dir, num_reducers):
     """Run group stage.
 
@@ -288,12 +307,7 @@ def group_stage(input_dir, output_dir, num_reducers):
         partition_keys(inpath, outpaths, input_keys_stats,
                        output_keys_stats, num_reducers)
 
-    # Log input keyspace stats
-    all_input_keys = set()
-    for inpath, keys in sorted(input_keys_stats.items()):
-        all_input_keys.update(keys)
-        LOGGER.debug("%s unique_keys=%s", last_two(inpath), len(keys))
-    LOGGER.debug("%s all_unique_keys=%s", input_dir.name, len(all_input_keys))
+    log_input_key_stats(input_keys_stats, input_dir)
 
     # Log partition input and output filenames
     outnames = [i.name for i in outpaths]
@@ -315,13 +329,7 @@ def group_stage(input_dir, output_dir, num_reducers):
     with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
         pool.map(sort_file, sorted(output_dir.iterdir()))
 
-    # Log output keyspace stats
-    all_output_keys = set()
-    for outpath, keys in sorted(output_keys_stats.items()):
-        all_output_keys.update(keys)
-        LOGGER.debug("%s unique_keys=%s", last_two(outpath), len(keys))
-    LOGGER.debug("%s all_unique_keys=%s", output_dir.name,
-                 len(all_output_keys))
+    log_output_key_stats(output_keys_stats, output_dir)
 
 
 def reduce_single_file(exe, input_path, output_path):

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -24,6 +24,7 @@ LOGGER = logging.getLogger("madoop")
 
 
 def mapreduce(
+    *,
     input_path,
     output_dir,
     map_exe,
@@ -292,7 +293,9 @@ def partition_keys_custom(
     Update the data structures provided by the caller input_keys_stats and
     output_keys_stats.  Both map a filename to a set of of keys.
     """
-    # pylint: disable=too-many-arguments,too-many-locals
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-positional-arguments
+    # pylint: disable=too-many-locals
     assert len(outpaths) == num_reducers
     outparent = outpaths[0].parent
     assert all(i.parent == outparent for i in outpaths)

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -221,7 +221,10 @@ def map_stage(exe, input_dir, output_dir):
                     chunk,
                 ))
                 part_num += 1
-    concurrent.futures.wait(futures)
+    for future in concurrent.futures.as_completed(futures):
+        exception = future.exception()
+        if exception:
+            raise exception
     LOGGER.info("Finished map executions: %s", part_num)
 
 
@@ -369,7 +372,10 @@ def reduce_stage(exe, input_dir, output_dir):
                 input_path,
                 output_path,
             ))
-    concurrent.futures.wait(futures)
+    for future in concurrent.futures.as_completed(futures):
+        exception = future.exception()
+        if exception:
+            raise exception
     LOGGER.info("Finished reduce executions: %s", i+1)
 
 

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -119,7 +119,7 @@ def split_file(input_filename, max_chunksize):
                 # for the next chunk.
                 yield buffer[:last_newline + 1]
 
-                # Remove unprocessed data from the buffer. The next chunk will
+                # Remove processed data from the buffer. The next chunk will
                 # start with whatever data came after the last newline.
                 buffer = buffer[last_newline + 1:]
 

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -32,12 +32,7 @@ def mapreduce(
     num_reducers,
     partitioner=None,
 ):
-    """Madoop API.
-
-    The number of reducers is dynamically determined by the number of unique
-    keys but will not be more than num_reducers
-
-    """
+    """Madoop API."""
     # pylint: disable=too-many-arguments
     # Do not clobber existing output directory
     output_dir = pathlib.Path(output_dir)

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -85,7 +85,7 @@ def mapreduce(input_path, output_dir, map_exe, reduce_exe, num_reducers):
         for filename in sorted(reduce_output_dir.glob("*")):
             st_size = filename.stat().st_size
             total_size += st_size
-            shutil.copy(filename, output_dir)
+            shutil.move(filename, output_dir)
             output_path = output_dir.parent/last_two(filename)
             LOGGER.debug("%s size=%sB", output_path, st_size)
 

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -194,7 +194,7 @@ def map_single_chunk(exe, input_path, output_path, chunk):
         try:
             subprocess.run(
                 str(exe),
-                shell=True,
+                shell=False,
                 check=True,
                 input=chunk,
                 stdout=outfile,
@@ -415,7 +415,7 @@ def reduce_single_file(exe, input_path, output_path):
         try:
             subprocess.run(
                 str(exe),
-                shell=True,
+                shell=False,
                 check=True,
                 stdin=infile,
                 stdout=outfile,

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -329,8 +329,16 @@ def group_stage(input_dir, output_dir, num_reducers):
             path.unlink()
 
     # Sort output files
-    with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
+    try:
+        # Don't use a with statement here, because Coverage won't be able to
+        # detect code running in a subprocess if we do.
+        # https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
+        # pylint: disable=consider-using-with
+        pool = multiprocessing.Pool(processes=multiprocessing.cpu_count())
         pool.map(sort_file, sorted(output_dir.iterdir()))
+    finally:
+        pool.close()
+        pool.join()
 
     log_output_key_stats(output_keys_stats, output_dir)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,9 @@
 """System tests for the API interface."""
+from pathlib import Path
 import pytest
 import madoop
+from madoop.exceptions import MadoopError
+from madoop.mapreduce import map_stage, reduce_stage
 from . import utils
 from .utils import TESTDATA_DIR
 
@@ -53,6 +56,18 @@ def test_bash_executable(tmpdir):
     )
 
 
+def test_output_already_exists(tmpdir):
+    """Output already existing should raise an error."""
+    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
+        madoop.mapreduce(
+            input_path=TESTDATA_DIR/"word_count/input",
+            output_dir=tmpdir,
+            map_exe=TESTDATA_DIR/"word_count/map.py",
+            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            num_reducers=2,
+        )
+
+
 def test_bad_map_exe(tmpdir):
     """Map exe returns non-zero should produce an error message."""
     with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
@@ -62,6 +77,23 @@ def test_bad_map_exe(tmpdir):
             map_exe=TESTDATA_DIR/"word_count/map_invalid.py",
             reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
             num_reducers=4
+        )
+
+    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
+        map_stage(
+            exe=TESTDATA_DIR/"word_count/map_invalid.py",
+            input_dir=TESTDATA_DIR/"word_count/input",
+            output_dir=Path(tmpdir),
+        )
+
+
+def test_bad_reduce_exe(tmpdir):
+    """Reduce exe returns non-zero should produce an error message."""
+    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
+        reduce_stage(
+            exe=TESTDATA_DIR/"word_count/reduce_exit_1.py",
+            input_dir=TESTDATA_DIR/"word_count/input",
+            output_dir=Path(tmpdir),
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 import pytest
 import madoop
-from madoop.exceptions import MadoopError
 from madoop.mapreduce import map_stage, reduce_stage
 from . import utils
 from .utils import TESTDATA_DIR

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,6 @@
 """System tests for the command line interface."""
 import subprocess
-import pkg_resources
+import importlib.metadata
 import pytest
 from . import utils
 from .utils import TESTDATA_DIR
@@ -15,7 +15,7 @@ def test_version():
     )
     output = result.stdout.decode("utf-8")
     assert "Madoop" in output
-    assert pkg_resources.get_distribution("madoop").version in output
+    assert importlib.metadata.version("madoop") in output
 
 
 def test_help():

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,6 +1,13 @@
 """System tests for the map stage of Michigan Hadoop."""
+import shutil
 from pathlib import Path
-from madoop.mapreduce import map_stage, group_stage, reduce_stage
+from madoop.mapreduce import (
+    map_stage,
+    group_stage,
+    reduce_stage,
+    split_file,
+    MAX_INPUT_SPLIT_SIZE,
+)
 from . import utils
 from .utils import TESTDATA_DIR
 
@@ -68,3 +75,44 @@ def test_reduce_stage_2_reducers(tmpdir):
         TESTDATA_DIR/"word_count/correct/reducer-output-2-reducers",
         tmpdir,
     )
+
+
+def test_input_splitting(tmp_path):
+    """Test that the Map Stage correctly splits input."""
+    input_data = "o" * (MAX_INPUT_SPLIT_SIZE - 10) + "\n" + \
+        "a" * int(MAX_INPUT_SPLIT_SIZE / 2)
+    input_dir = tmp_path/"input"
+    output_dir = tmp_path/"output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    with open(input_dir/"input.txt", "w", encoding="utf-8") as input_file:
+        input_file.write(input_data)
+
+    map_stage(
+        exe=Path(shutil.which("cat")),
+        input_dir=input_dir,
+        output_dir=output_dir,
+    )
+
+    output_files = sorted(output_dir.glob("*"))
+    assert len(output_files) == 2
+    assert output_files == [output_dir/"part-00000", output_dir/"part-00001"]
+
+    with open(output_dir/"part-00000", "r", encoding="utf-8") as outfile1:
+        data = outfile1.read()
+        assert data == "o" * (MAX_INPUT_SPLIT_SIZE - 10) + "\n"
+    with open(output_dir/"part-00001", "r", encoding="utf-8") as outfile2:
+        data = outfile2.read()
+        assert data == "a" * int(MAX_INPUT_SPLIT_SIZE / 2)
+
+
+def test_split_file_mid_chunk(tmp_path):
+    """Test that file splitting still works when data remains in the buffer."""
+    input_data = "noah says\nhello world"
+    input_file = tmp_path/"input.txt"
+    with open(input_file, "w", encoding="utf-8") as infile:
+        infile.write(input_data)
+
+    splits = list(split_file(input_file, 50))
+    assert splits == [b"noah says\n", b"hello world"]

--- a/tests/testdata/word_count/reduce_exit_1.py
+++ b/tests/testdata/word_count/reduce_exit_1.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Invalid reduce executable exits 1."""
+
+import sys
+
+sys.exit(1)


### PR DESCRIPTION
Closes #34, closes #69. I deliberately chose not to make these two changes:

> Do not store both map output and partitioned map output. Instead, pipe map output directly to partition function.
Do not store both sorted and unsorted group output. Instead, read partitioned mapper output into memory (one file). Sort it. Pipe sorted output to reducer input.

I'm worried that, although these are legitimate optimizations, they would make Madoop significantly more similar to a project 4 solution. We would in fact be verbatim ripping off code from project 4, losing some of Madoop's distinctiveness in the process. Open to debate/suggestions on this though.

With regard to this:
> Measure run time with a large input (e.g., EECS 485 Project 5 Wikipedia input) and optimize input partition size.

I measured the runtime of project 5's job 1 and job 2 and found that, on my machine, it truthfully doesn't matter very much. Job 1, which is by far the slowest, is unaffected entirely since the actual input to the framework is minuscule (just a file with ~3,000 filenames,which I consider a severe flaw of the recent HTML dataset changes--see [this comment](https://github.com/eecs485staff/p5-search-engine/issues/686#issuecomment-1822599805)). Job 2 is minimally affected some of the time, but not all the time, and any chunk size higher than ~18 MB is pointless due to the size of the input files. I went with 10 MB as a compromise, as this and anything higher does seem to subtract a few seconds some of the time.