### PR TITLE
Get version with importlib.metadata

### DIFF
--- a/madoop/__main__.py
+++ b/madoop/__main__.py
@@ -4,12 +4,12 @@ Andrew DeOrio <awdeorio@umich.edu>
 
 """
 import argparse
+import importlib.metadata
 import logging
 import pathlib
 import shutil
 import sys
 import textwrap
-import pkg_resources
 from .mapreduce import mapreduce
 from .exceptions import MadoopError
 
@@ -21,10 +21,10 @@ def main():
     )
 
     optional_args = parser.add_argument_group('optional arguments')
-    version = pkg_resources.get_distribution("madoop").version
+
     optional_args.add_argument(
         '--version', action='version',
-        version=f'Madoop {version}'
+        version=f'Madoop {importlib.metadata.version("madoop")}'
     )
     optional_args.add_argument(
         '--example', action=ExampleAction, nargs=0,


### PR DESCRIPTION
Modernize how Madoop obtains its own version string for the `--version` flag implementation.

On some installs, we get an error
```console
$ madoop  --version
Traceback (most recent call last):
  File "/opt/homebrew/bin/madoop", line 5, in <module>
    from madoop.__main__ import main
  File "/opt/homebrew/lib/python3.11/site-packages/madoop/__main__.py", line 12, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

It looks like `pkg_resources` is [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html) and is replaced by [`importlib.metadata`](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata)