### PR TITLE
Catch more `OSError`s

### DIFF
--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -199,7 +199,7 @@ def map_single_chunk(exe, input_path, output_path, chunk):
                 input=chunk,
                 stdout=outfile,
             )
-        except subprocess.CalledProcessError as err:
+        except (subprocess.CalledProcessError, OSError) as err:
             raise MadoopError(
                 f"Command returned non-zero: "
                 f"{exe} < {input_path} > {output_path}"
@@ -420,7 +420,7 @@ def reduce_single_file(exe, input_path, output_path):
                 stdin=infile,
                 stdout=outfile,
             )
-        except subprocess.CalledProcessError as err:
+        except (subprocess.CalledProcessError, OSError) as err:
             raise MadoopError(
                 f"Command returned non-zero: "
                 f"{exe} < {input_path} > {output_path}"


### PR DESCRIPTION
We should probably catch `OSError`s in all places where we use `subprocess.run()` instead of just `is_executable()`. I originally thought we were already doing it and lost it in a merge conflict, but we never were in the first place.