### PR TITLE
Report subprocess error messages

### DIFF
--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -177,8 +177,8 @@ def is_executable(exe):
         )
     except subprocess.CalledProcessError as err:
         raise MadoopError(
-            f"Failed executable test: {err}\n"
-            f"{err.stdout.decode()}" if err.stdout else ""
+            f"Failed executable test: {err}"
+            f"\n{err.stdout.decode()}" if err.stdout else ""
             f"{err.stderr.decode()}" if err.stderr else ""
         ) from err
     except OSError as err:
@@ -212,8 +212,8 @@ def map_single_chunk(exe, input_path, output_path, chunk):
             raise MadoopError(
                 f"Command returned non-zero: "
                 f"{exe} < {input_path} > {output_path}\n"
-                f"{err}\n"
-                f"{err.stderr.decode()}" if err.stderr else ""
+                f"{err}"
+                f"\n{err.stderr.decode()}" if err.stderr else ""
             ) from err
         except OSError as err:
             raise MadoopError(f"Command returned non-zero: {err}") from err
@@ -441,8 +441,8 @@ def reduce_single_file(exe, input_path, output_path):
             raise MadoopError(
                 f"Command returned non-zero: "
                 f"{exe} < {input_path} > {output_path}\n"
-                f"{err}\n"
-                f"{err.stderr.decode()}" if err.stderr else ""
+                f"{err}"
+                f"\n{err.stderr.decode()}" if err.stderr else ""
             ) from err
         except OSError as err:
             raise MadoopError(f"Command returned non-zero: {err}") from err

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -213,7 +213,6 @@ def map_single_chunk(exe, input_path, output_path, chunk):
                 f"Command returned non-zero: "
                 f"{exe} < {input_path} > {output_path}\n"
                 f"{err}\n"
-                f"{err.stdout.decode()}" if err.stdout else ""
                 f"{err.stderr.decode()}" if err.stderr else ""
             ) from err
         except OSError as err:
@@ -342,10 +341,8 @@ def partition_keys_custom(
         return_code = process.wait()
         if return_code:
             stderr_output = process.stderr.read()
-            if len(stderr_output) != 0:
-                stderr_output = '\n' + stderr_output
             raise MadoopError(
-                f"Partition executable returned non-zero: {str(partitioner)}"
+                f"Partition executable returned non-zero: {str(partitioner)}\n"
                 f"{stderr_output}"
             )
 
@@ -445,7 +442,6 @@ def reduce_single_file(exe, input_path, output_path):
                 f"Command returned non-zero: "
                 f"{exe} < {input_path} > {output_path}\n"
                 f"{err}\n"
-                f"{err.stdout.decode()}" if err.stdout else ""
                 f"{err.stderr.decode()}" if err.stderr else ""
             ) from err
         except OSError as err:

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -43,6 +43,8 @@ def mapreduce(
     # Executable scripts must have valid shebangs
     is_executable(map_exe)
     is_executable(reduce_exe)
+    if partitioner:
+        is_executable(partitioner)
 
     # Create a tmp directory which will be automatically cleaned up
     with tempfile.TemporaryDirectory(prefix="madoop-") as tmpdir:

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -173,12 +173,14 @@ def is_executable(exe):
             stderr=subprocess.PIPE,
             check=True,
         )
-    except (subprocess.CalledProcessError, OSError) as err:
-        stderr_output = ""
-        if isinstance(err, subprocess.CalledProcessError) and err.stderr:
-            stderr_output = '\n' + err.stderr.decode()
-        raise MadoopError(f"Failed executable test: {err}"
-                          f"{stderr_output}") from err
+    except subprocess.CalledProcessError as err:
+        raise MadoopError(
+            f"Failed executable test: {err}\n"
+            f"{err.stdout.decode()}" if err.stdout else ""
+            f"{err.stderr.decode()}" if err.stderr else ""
+        ) from err
+    except OSError as err:
+        raise MadoopError(f"Failed executable test: {err}") from err
 
 
 def part_filename(num):
@@ -204,15 +206,16 @@ def map_single_chunk(exe, input_path, output_path, chunk):
                 stdout=outfile,
                 stderr=subprocess.PIPE
             )
-        except (subprocess.CalledProcessError, OSError) as err:
-            stderr_output = ""
-            if isinstance(err, subprocess.CalledProcessError) and err.stderr:
-                stderr_output = '\n' + err.stderr.decode()
+        except subprocess.CalledProcessError as err:
             raise MadoopError(
                 f"Command returned non-zero: "
-                f"{exe} < {input_path} > {output_path}"
-                f"{stderr_output}"
+                f"{exe} < {input_path} > {output_path}\n"
+                f"{err}\n"
+                f"{err.stdout.decode()}" if err.stdout else ""
+                f"{err.stderr.decode()}" if err.stderr else ""
             ) from err
+        except OSError as err:
+            raise MadoopError(f"Command returned non-zero: {err}") from err
 
 
 def map_stage(exe, input_dir, output_dir):
@@ -435,15 +438,16 @@ def reduce_single_file(exe, input_path, output_path):
                 stdout=outfile,
                 stderr=subprocess.PIPE
             )
-        except (subprocess.CalledProcessError, OSError) as err:
-            stderr_output = ""
-            if isinstance(err, subprocess.CalledProcessError) and err.stderr:
-                stderr_output = '\n' + err.stderr.decode()
+        except subprocess.CalledProcessError as err:
             raise MadoopError(
                 f"Command returned non-zero: "
-                f"{exe} < {input_path} > {output_path}"
-                f"{stderr_output}"
+                f"{exe} < {input_path} > {output_path}\n"
+                f"{err}\n"
+                f"{err.stdout.decode()}" if err.stdout else ""
+                f"{err.stderr.decode()}" if err.stderr else ""
             ) from err
+        except OSError as err:
+            raise MadoopError(f"Command returned non-zero: {err}") from err
 
 
 def reduce_stage(exe, input_dir, output_dir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -214,8 +214,10 @@ def test_map_exe_error_msg(tmpdir):
     """Map exe returns non-zero with stderr output should produce an
     error message and forward the stderr output.
     """
-    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError,
-                                        match="Map error message"):
+    with tmpdir.as_cwd(), pytest.raises(
+        madoop.MadoopError,
+        match="Map error message to stderr"
+    ):
         madoop.mapreduce(
             input_path=TESTDATA_DIR/"word_count/input",
             output_dir="output",
@@ -225,8 +227,10 @@ def test_map_exe_error_msg(tmpdir):
             partitioner=None,
         )
 
-    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError,
-                                        match="Map error message"):
+    with tmpdir.as_cwd(), pytest.raises(
+        madoop.MadoopError,
+        match="Map error message to stderr"
+    ):
         map_stage(
             exe=TESTDATA_DIR/"word_count/map_error_msg.py",
             input_dir=TESTDATA_DIR/"word_count/input",
@@ -238,8 +242,10 @@ def test_partition_exe_error_msg(tmpdir):
     """Partition exe returns non-zero with stderr output should produce an
     error message and forward the stderr output.
     """
-    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError,
-                                        match="Partition error message"):
+    with tmpdir.as_cwd(), pytest.raises(
+        madoop.MadoopError,
+        match="Partition error message to stderr"
+    ):
         madoop.mapreduce(
             input_path=TESTDATA_DIR/"word_count/input",
             output_dir="output",
@@ -254,8 +260,10 @@ def test_reduce_exe_error_msg(tmpdir):
     """Reduce exe returns non-zero with stderr output should produce an
     error message and forward the stderr output.
     """
-    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError,
-                                        match="Reduce error message"):
+    with tmpdir.as_cwd(), pytest.raises(
+        madoop.MadoopError,
+        match="Reduce error message to stderr"
+    ):
         reduce_stage(
             exe=TESTDATA_DIR/"word_count/reduce_error_msg.py",
             input_dir=TESTDATA_DIR/"word_count/input",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -208,3 +208,56 @@ def test_input_path_spaces(tmpdir):
         TESTDATA_DIR/"word_count/correct/output",
         tmpdir/"output",
     )
+
+
+def test_map_exe_error_msg(tmpdir):
+    """Map exe returns non-zero with stderr output should produce an
+    error message and forward the stderr output.
+    """
+    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError,
+                                        match="Map error message"):
+        madoop.mapreduce(
+            input_path=TESTDATA_DIR/"word_count/input",
+            output_dir="output",
+            map_exe=TESTDATA_DIR/"word_count/map_error_msg.py",
+            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            num_reducers=4,
+            partitioner=None,
+        )
+
+    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError,
+                                        match="Map error message"):
+        map_stage(
+            exe=TESTDATA_DIR/"word_count/map_error_msg.py",
+            input_dir=TESTDATA_DIR/"word_count/input",
+            output_dir=Path(tmpdir),
+        )
+
+
+def test_partition_exe_error_msg(tmpdir):
+    """Partition exe returns non-zero with stderr output should produce an
+    error message and forward the stderr output.
+    """
+    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError,
+                                        match="Partition error message"):
+        madoop.mapreduce(
+            input_path=TESTDATA_DIR/"word_count/input",
+            output_dir="output",
+            map_exe=TESTDATA_DIR/"word_count/map.py",
+            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            num_reducers=4,
+            partitioner=TESTDATA_DIR/"word_count/partition_error_msg.py",
+        )
+
+
+def test_reduce_exe_error_msg(tmpdir):
+    """Reduce exe returns non-zero with stderr output should produce an
+    error message and forward the stderr output.
+    """
+    with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError,
+                                        match="Reduce error message"):
+        reduce_stage(
+            exe=TESTDATA_DIR/"word_count/reduce_error_msg.py",
+            input_dir=TESTDATA_DIR/"word_count/input",
+            output_dir=Path(tmpdir),
+        )

--- a/tests/testdata/word_count/map_error_msg.py
+++ b/tests/testdata/word_count/map_error_msg.py
@@ -3,5 +3,6 @@
 
 import sys
 
-sys.stderr.write("Map error message")
+sys.stdout.write("Map error message to stdout\n")
+sys.stderr.write("Map error message to stderr\n")
 sys.exit(1)

--- a/tests/testdata/word_count/map_error_msg.py
+++ b/tests/testdata/word_count/map_error_msg.py
@@ -7,6 +7,5 @@ import sys
 # Avoid error on executable check which has an empty string input
 input_lines_n = sum(1 for _ in sys.stdin)
 if input_lines_n > 1:
-    sys.stdout.write("Map error message to stdout\n")
     sys.stderr.write("Map error message to stderr\n")
     sys.exit(1)

--- a/tests/testdata/word_count/map_error_msg.py
+++ b/tests/testdata/word_count/map_error_msg.py
@@ -3,6 +3,10 @@
 
 import sys
 
-sys.stdout.write("Map error message to stdout\n")
-sys.stderr.write("Map error message to stderr\n")
-sys.exit(1)
+
+# Avoid error on executable check which has an empty string input
+input_lines_n = sum(1 for _ in sys.stdin)
+if input_lines_n > 1:
+    sys.stdout.write("Map error message to stdout\n")
+    sys.stderr.write("Map error message to stderr\n")
+    sys.exit(1)

--- a/tests/testdata/word_count/map_error_msg.py
+++ b/tests/testdata/word_count/map_error_msg.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Invalid map executable returns non-zero with an error message."""
+
+import sys
+
+sys.stderr.write("Map error message")
+sys.exit(1)

--- a/tests/testdata/word_count/partition_error_msg.py
+++ b/tests/testdata/word_count/partition_error_msg.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Invalid partition executable returns non-zero with an error message."""
+
+import sys
+
+sys.stderr.write("Partition error message")
+sys.exit(1)

--- a/tests/testdata/word_count/partition_error_msg.py
+++ b/tests/testdata/word_count/partition_error_msg.py
@@ -3,6 +3,9 @@
 
 import sys
 
-sys.stderr.write("Partition error message to stdout\n")
-sys.stderr.write("Partition error message to stderr\n")
-sys.exit(1)
+# Avoid error on executable check which has an empty string input
+input_lines_n = sum(1 for _ in sys.stdin)
+if input_lines_n > 1:
+    sys.stderr.write("Partition error message to stdout\n")
+    sys.stderr.write("Partition error message to stderr\n")
+    sys.exit(1)

--- a/tests/testdata/word_count/partition_error_msg.py
+++ b/tests/testdata/word_count/partition_error_msg.py
@@ -3,5 +3,6 @@
 
 import sys
 
-sys.stderr.write("Partition error message")
+sys.stderr.write("Partition error message to stdout\n")
+sys.stderr.write("Partition error message to stderr\n")
 sys.exit(1)

--- a/tests/testdata/word_count/reduce_error_msg.py
+++ b/tests/testdata/word_count/reduce_error_msg.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Invalid reduce executable returns non-zero with an error message."""
+
+import sys
+
+sys.stderr.write("Reduce error message")
+sys.exit(1)

--- a/tests/testdata/word_count/reduce_error_msg.py
+++ b/tests/testdata/word_count/reduce_error_msg.py
@@ -3,5 +3,6 @@
 
 import sys
 
-sys.stderr.write("Reduce error message")
+sys.stdout.write("Reduce error message to stdout\n")
+sys.stderr.write("Reduce error message to stderr\n")
 sys.exit(1)

--- a/tests/testdata/word_count/reduce_error_msg.py
+++ b/tests/testdata/word_count/reduce_error_msg.py
@@ -7,6 +7,5 @@ import sys
 # Avoid error on executable check which has an empty string input
 input_lines_n = sum(1 for _ in sys.stdin)
 if input_lines_n > 1:
-    sys.stdout.write("Reduce error message to stdout\n")
     sys.stderr.write("Reduce error message to stderr\n")
     sys.exit(1)

--- a/tests/testdata/word_count/reduce_error_msg.py
+++ b/tests/testdata/word_count/reduce_error_msg.py
@@ -3,6 +3,10 @@
 
 import sys
 
-sys.stdout.write("Reduce error message to stdout\n")
-sys.stderr.write("Reduce error message to stderr\n")
-sys.exit(1)
+
+# Avoid error on executable check which has an empty string input
+input_lines_n = sum(1 for _ in sys.stdin)
+if input_lines_n > 1:
+    sys.stdout.write("Reduce error message to stdout\n")
+    sys.stderr.write("Reduce error message to stderr\n")
+    sys.exit(1)


### PR DESCRIPTION
Closes #50. I planned on doing this along with my first PR, but I forgot about it until now.

I appended the error message as-is to the `MadoopError`. This risks making the error messages a bit cluttered though, so any ideas for a cleaner format are welcome.