### PR TITLE
Add Pipeline Debugging Tip: Print to stderr

### DIFF
--- a/README_Hadoop_Streaming.md
+++ b/README_Hadoop_Streaming.md
@@ -289,6 +289,13 @@ if __name__ == "__main__":
 ## Tips and tricks
 These are some pro-tips for working with MapReduce programs written in Python for the Hadoop Streaming interface.
 
+### Printing to `stderr`
+To avoid interfering with pipeline output in `stdout`, direct debugging print messages to `stderr`:
+
+```python
+print("finding bugs... ~(^._.)", file=sys.stderr)
+```
+
 ### Debugging
 We encounter a problem if we add a `breakpoint()` in `map.py`.
 ```python

--- a/README_Hadoop_Streaming.md
+++ b/README_Hadoop_Streaming.md
@@ -293,7 +293,7 @@ These are some pro-tips for working with MapReduce programs written in Python fo
 To avoid interfering with pipeline output in `stdout`, direct debugging print messages to `stderr`:
 
 ```python
-print("finding bugs... ~(^._.)", file=sys.stderr)
+print("DEBUG finding bugs... ~(^._.)", file=sys.stderr)
 ```
 
 ### Debugging

--- a/README_Hadoop_Streaming.md
+++ b/README_Hadoop_Streaming.md
@@ -306,13 +306,13 @@ for line in sys.stdin:
         print(f"{word}\t1")
 ```
 
-PDB/PDB++ confuses the stdin being piped in from the input file for user input, so we get these errors:
+PDB confuses the stdin being piped in from the input file for user input, so we get these errors:
 ```console
 $ cat input/input* | ./map.py
 ...
-(Pdb++) *** SyntaxError: invalid syntax
-(Pdb++) *** SyntaxError: invalid syntax
-(Pdb++) *** SyntaxError: invalid syntax
+(Pdb) *** SyntaxError: invalid syntax
+(Pdb) *** SyntaxError: invalid syntax
+(Pdb) *** SyntaxError: invalid syntax
 ...
 ```
 
@@ -332,7 +332,7 @@ Now our debugger works correctly.
 ```console
 $ cat input/input* | ./map.py
 ...
-(Pdb++)
+(Pdb)
 ```
 
 Don't forget to remove your temporary changes!

--- a/README_Hadoop_Streaming.md
+++ b/README_Hadoop_Streaming.md
@@ -289,14 +289,14 @@ if __name__ == "__main__":
 ## Tips and tricks
 These are some pro-tips for working with MapReduce programs written in Python for the Hadoop Streaming interface.
 
-### Printing to `stderr`
+### Print debug messages to `stderr`
 To avoid interfering with pipeline output in `stdout`, direct debugging print messages to `stderr`:
 
 ```python
 print("DEBUG finding bugs... ~(^._.)", file=sys.stderr)
 ```
 
-### Debugging
+### Debugging with PDB
 We encounter a problem if we add a `breakpoint()` in `map.py`.
 ```python
 for line in sys.stdin:


### PR DESCRIPTION
Add pipeline debugging tip. Print to stderr.

Closes p5-search-engine issue [#727](https://github.com/eecs485staff/p5-search-engine/issues/727)