### PR TITLE
Modernize Python version config and CI infra

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,8 @@
 [run]
 concurrency = thread,multiprocessing
 parallel = true
+
+# Short-lived multiprocessing Pool workers and subprocess helpers sometimes
+# exit before running any measurable Python, which is expected.  Silence the
+# resulting "No data was collected" noise.
+disable_warnings = no-data-collected

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -19,9 +19,9 @@ jobs:
     name: Tests ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-      # Define OS and Python versions to use. 3.x is the latest minor version.
+      # Define OS and Python versions to use.
       matrix:
-        python-version: ["3.x"]  # 3.x is the latest minor version
+        python-version: ["3.9", "3.x"]  # floor and latest minor version
         os: [ubuntu-latest]
 
     # Sequence of tasks for this job
@@ -29,24 +29,22 @@ jobs:
       # Check out latest code
       # Docs: https://github.com/actions/checkout
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Set up Python
       # Docs: https://github.com/actions/setup-python
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       # Install dependencies
-      # https://github.com/ymyzk/tox-gh-actions#workflow-configuration
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install coverage tox tox-gh-actions
+          pip install coverage tox
 
       # Run tests
-      # https://github.com/ymyzk/tox-gh-actions#workflow-configuration
       - name: Run tests
         run: tox
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -29,12 +29,12 @@ jobs:
       # Check out latest code
       # Docs: https://github.com/actions/checkout
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Set up Python
       # Docs: https://github.com/actions/setup-python
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -55,7 +55,7 @@ jobs:
       # Upload coverage report
       # https://github.com/codecov/codecov-action
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: eecs485staff/madoop

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Madoop: Michigan Hadoop
 =======================
 
 [![PyPI](https://img.shields.io/pypi/v/madoop.svg)](https://pypi.org/project/madoop/)
-[![CI main](https://github.com/eecs485staff/madoop/workflows/CI/badge.svg?branch=develop)](https://github.com/eecs485staff/madoop/actions?query=branch%3Adevelop)
+[![CI main](https://github.com/eecs485staff/madoop/actions/workflows/continuous_integration.yml/badge.svg?branch=develop)](https://github.com/eecs485staff/madoop/actions/workflows/continuous_integration.yml?query=branch%3Adevelop)
 [![codecov](https://codecov.io/gh/eecs485staff/madoop/branch/develop/graph/badge.svg)](https://codecov.io/gh/eecs485staff/madoop)
 
 Michigan Hadoop (`madoop`) is a light weight MapReduce framework for education.  Madoop implements the [Hadoop Streaming](https://hadoop.apache.org/docs/r1.2.1/streaming.html) interface.  Madoop is implemented in Python and runs on a single machine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 keywords = [
   "madoop", "Hadoop", "MapReduce", "Michigan Hadoop", "Hadoop Streaming"
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 
 [project.urls]
 repository = "https://github.com/eecs485staff/madoop/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,19 @@ keywords = [
   "madoop", "Hadoop", "MapReduce", "Michigan Hadoop", "Hadoop Streaming"
 ]
 requires-python = ">=3.9"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Education",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Education",
+]
 
 [project.urls]
 repository = "https://github.com/eecs485staff/madoop/"

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,8 @@
-# Local host configuration with one Python 3 version
+# Run against whatever Python 3 interpreter is active.  In CI the version is
+# chosen by the GitHub Actions matrix (the floor and the latest minor); locally
+# it's your system python3.
 [tox]
-envlist = py37, py38, py39, py310, py311
-
-# GitHub Actions configuration with multiple Python versions
-# https://github.com/ymyzk/tox-gh-actions#tox-gh-actions-configuration
-[gh-actions]
-python =
-  3.7: py37
-  3.8: py38
-  3.9: py39
-  3.10: py310
-  3.11: py311
+envlist = py3
 
 # Run unit tests
 # HACK: Pydocstyle fails to find tests.  Invoke a shell to use a glob.


### PR DESCRIPTION
Bring the Python version settings into agreement and refresh stale CI/packaging infra.

## Changes

- **Pin a real Python floor (3.9).** `pyproject.toml`, `tox.ini`, and CI all agreed to disagree: `requires-python` claimed `>=3.6`, tox tested 3.7-3.11, and CI ran only `3.x`. Now all three commit to `>=3.9` (3.6-3.8 are EOL). CI tests the floor and the latest minor (`["3.9", "3.x"]`), and tox runs a generic `py3` env against whatever interpreter the job provides, so "latest" tracks forward with nothing to maintain.
- **Bump GitHub Actions.** `actions/checkout` v2 -> v6, `actions/setup-python` v2 -> v6, `codecov/codecov-action` v4 -> v7. Dropped `tox-gh-actions` (no longer needed with the generic `py3` env).
- **Silence the `CoverageWarning: No data was collected` noise.** Short-lived multiprocessing Pool workers exit before running measurable Python; added `disable_warnings = no-data-collected` to `.coveragerc`.
- **Add packaging metadata.** Trove classifiers (Python 3.9-3.13, MIT license, Education) in `pyproject.toml`, and modernized the README CI badge URL.