### PR TITLE
Convert linting from pylint/pycodestyle/pydocstyle to ruff

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,0 @@
-[MASTER]
-
-# A comma-separated list of package or module names from where C extensions may
-# be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code.
-extension-pkg-allow-list=math
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ $ python3 -m venv .venv
 $ source .venv/bin/activate
 $ pip install --editable .[dev]
 
-# Run the full CI suite (file diffs, pycodestyle, pydocstyle, pylint,
+# Run the full CI suite (file diffs, ruff check, ruff format --check,
 # check-manifest, pytest with coverage) in a clean temp virtualenv
 $ tox -e py3
 
@@ -23,9 +23,8 @@ $ pytest tests/test_api.py::test_simple     # single test
 $ pytest --cov ./madoop --cov-report term-missing
 
 # Linters individually
-$ pycodestyle madoop tests
-$ pydocstyle madoop tests
-$ pylint madoop tests
+$ ruff check madoop tests
+$ ruff format --check madoop tests
 $ check-manifest
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,8 @@ $ pytest --cov ./madoop --cov-report term-missing
 
 Test code style
 ```console
-$ pycodestyle madoop tests setup.py
-$ pydocstyle madoop tests setup.py
-$ pylint madoop tests setup.py
+$ ruff check madoop tests
+$ ruff format --check madoop tests
 $ check-manifest
 ```
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include MANIFEST.in
 include README.md
 include README_Hadoop_Streaming.md
 include CONTRIBUTING.md
-include .pylintrc
 graft tests
 graft madoop/example
 

--- a/madoop/__init__.py
+++ b/madoop/__init__.py
@@ -3,5 +3,6 @@
 Andrew DeOrio <awdeorio@umich.edu>
 
 """
-from .mapreduce import mapreduce
-from .exceptions import MadoopError
+
+from .exceptions import MadoopError as MadoopError
+from .mapreduce import mapreduce as mapreduce

--- a/madoop/__main__.py
+++ b/madoop/__main__.py
@@ -3,6 +3,7 @@
 Andrew DeOrio <awdeorio@umich.edu>
 
 """
+
 import argparse
 import importlib.metadata
 import logging
@@ -12,50 +13,56 @@ import shutil
 import stat
 import sys
 import textwrap
-from .mapreduce import mapreduce
+
 from .exceptions import MadoopError
+from .mapreduce import mapreduce
 
 
 def main():
     """Parse command line arguments and options then call mapreduce()."""
     parser = argparse.ArgumentParser(
-        description='A light weight MapReduce framework for education.'
+        description="A light weight MapReduce framework for education."
     )
 
-    optional_args = parser.add_argument_group('optional arguments')
+    optional_args = parser.add_argument_group("optional arguments")
 
     optional_args.add_argument(
-        '--version', action='version',
-        version=f'Madoop {importlib.metadata.version("madoop")}'
+        "--version",
+        action="version",
+        version=f"Madoop {importlib.metadata.version('madoop')}",
     )
     optional_args.add_argument(
-        '--example', action=ExampleAction, nargs=0,
+        "--example",
+        action=ExampleAction,
+        nargs=0,
         help="create example MapReduce program and input files",
     )
     optional_args.add_argument(
-        '-v', '--verbose', action='count', default=0,
-        help="verbose output"
+        "-v", "--verbose", action="count", default=0, help="verbose output"
     )
     optional_args.add_argument(
-        '-numReduceTasks', dest='num_reducers', default=4,
-        help="max number of reducers"
+        "-numReduceTasks", dest="num_reducers", default=4, help="max number of reducers"
     )
     optional_args.add_argument(
-        '-partitioner', dest='partitioner', default=None,
-        help=("executable that computes a partition for each key-value pair "
-              "of map output: default is hash(key) %% num_reducers"),
+        "-partitioner",
+        dest="partitioner",
+        default=None,
+        help=(
+            "executable that computes a partition for each key-value pair "
+            "of map output: default is hash(key) %% num_reducers"
+        ),
     )
-    required_args = parser.add_argument_group('required arguments')
-    required_args.add_argument('-input', dest='input', required=True)
-    required_args.add_argument('-output', dest='output', required=True)
-    required_args.add_argument('-mapper', dest='mapper', required=True)
-    required_args.add_argument('-reducer', dest='reducer', required=True)
+    required_args = parser.add_argument_group("required arguments")
+    required_args.add_argument("-input", dest="input", required=True)
+    required_args.add_argument("-output", dest="output", required=True)
+    required_args.add_argument("-mapper", dest="mapper", required=True)
+    required_args.add_argument("-reducer", dest="reducer", required=True)
 
     args, _ = parser.parse_known_args()
 
     # Handle verbose flag with logging configuration
     handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter('%(levelname)s: %(message)s')
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
     handler.setFormatter(formatter)
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)
@@ -87,29 +94,27 @@ class ExampleAction(argparse.Action):
     Doc: https://docs.python.org/3/library/argparse.html#argparse.Action
     """
 
-    # Python 3.6 pylint bug work around
-    # pylint: disable=too-few-public-methods
-
     def __init__(self, *args, **kwargs):
         """Call parent class init."""
         super().__init__(*args, **kwargs)
 
-    def __call__(self, parser, *args, **kwargs):
+    def __call__(self, parser, *_args, **_kwargs):
         """Copy example/ directory to PWD."""
         madoop_dir = pathlib.Path(__file__).parent
-        src = madoop_dir/"example"
+        src = madoop_dir / "example"
         dst = pathlib.Path("example")
         if dst.exists():
             parser.error(f"directory already exists: {dst}")
         shutil.copytree(src, dst)
 
         # Set executable bit
-        st = os.stat(dst/"map.py")
-        os.chmod(dst/"map.py", st.st_mode | stat.S_IEXEC)
-        st = os.stat(dst/"reduce.py")
-        os.chmod(dst/"reduce.py", st.st_mode | stat.S_IEXEC)
+        st = os.stat(dst / "map.py")
+        os.chmod(dst / "map.py", st.st_mode | stat.S_IEXEC)
+        st = os.stat(dst / "reduce.py")
+        os.chmod(dst / "reduce.py", st.st_mode | stat.S_IEXEC)
 
-        print(textwrap.dedent(f"""\
+        print(
+            textwrap.dedent(f"""\
             Created {dst}, try:
 
             madoop \\
@@ -117,9 +122,10 @@ class ExampleAction(argparse.Action):
               -output example/output \\
               -mapper example/map.py \\
               -reducer example/reduce.py\
-        """))
+        """)
+        )
         parser.exit()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/madoop/example/map.py
+++ b/madoop/example/map.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Word count mapper."""
-import sys
 
+import sys
 
 for line in sys.stdin:
     words = line.split()

--- a/madoop/example/reduce.py
+++ b/madoop/example/reduce.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Word count reducer."""
-import sys
+
 import itertools
+import sys
 
 
 def main():

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -3,18 +3,19 @@
 Andrew DeOrio <awdeorio@umich.edu>
 
 """
-import contextlib
+
 import collections
+import concurrent.futures
+import contextlib
 import hashlib
 import logging
+import multiprocessing
 import pathlib
 import shutil
 import subprocess
 import tempfile
-import multiprocessing
-import concurrent.futures
-from .exceptions import MadoopError
 
+from .exceptions import MadoopError
 
 # Large input files are automatically split
 MAX_INPUT_SPLIT_SIZE = 10 * 1024 * 1024  # 10 MB
@@ -23,7 +24,7 @@ MAX_INPUT_SPLIT_SIZE = 10 * 1024 * 1024  # 10 MB
 LOGGER = logging.getLogger("madoop")
 
 
-def mapreduce(
+def mapreduce(  # noqa: PLR0913
     *,
     input_path,
     output_dir,
@@ -33,7 +34,6 @@ def mapreduce(
     partitioner=None,
 ):
     """Madoop API."""
-    # pylint: disable=too-many-arguments
     # Do not clobber existing output directory
     output_dir = pathlib.Path(output_dir)
     if output_dir.exists():
@@ -48,14 +48,14 @@ def mapreduce(
         is_executable(partitioner, str(num_reducers))
 
     # Create a tmp directory which will be automatically cleaned up
-    with tempfile.TemporaryDirectory(prefix="madoop-") as tmpdir:
-        tmpdir = pathlib.Path(tmpdir)
+    with tempfile.TemporaryDirectory(prefix="madoop-") as tmpdir_str:
+        tmpdir = pathlib.Path(tmpdir_str)
         LOGGER.debug("tmpdir=%s", tmpdir)
 
         # Create stage input and output directory
-        map_output_dir = tmpdir/'mapper-output'
-        reduce_input_dir = tmpdir/'reducer-input'
-        reduce_output_dir = tmpdir/'output'
+        map_output_dir = tmpdir / "mapper-output"
+        reduce_input_dir = tmpdir / "reducer-input"
+        reduce_output_dir = tmpdir / "output"
         map_output_dir.mkdir()
         reduce_input_dir.mkdir()
         reduce_output_dir.mkdir()
@@ -98,7 +98,7 @@ def mapreduce(
             st_size = filename.stat().st_size
             total_size += st_size
             shutil.move(filename, output_dir)
-            output_path = output_dir.parent/last_two(filename)
+            output_path = output_dir.parent / last_two(filename)
             LOGGER.debug("%s size=%sB", output_path, st_size)
 
     # Remind user where to find output
@@ -127,11 +127,11 @@ def split_file(input_filename, max_chunksize):
             if last_newline != -1:
                 # Yield the content up to the last newline, saving the rest
                 # for the next chunk.
-                yield buffer[:last_newline + 1]
+                yield buffer[: last_newline + 1]
 
                 # Remove processed data from the buffer. The next chunk will
                 # start with whatever data came after the last newline.
-                buffer = buffer[last_newline + 1:]
+                buffer = buffer[last_newline + 1 :]
 
         # Yield any remaining data.
         if buffer:
@@ -147,7 +147,7 @@ def normalize_input_paths(input_path):
     """
     input_paths = []
     if input_path.is_dir():
-        for path in sorted(input_path.glob('*')):
+        for path in sorted(input_path.glob("*")):
             if path.is_file():
                 input_paths.append(path)
             else:
@@ -171,16 +171,17 @@ def is_executable(exe, *args):
         subprocess.run(
             [str(exe), *args],
             shell=False,
-            input="".encode(),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            input=b"",
+            capture_output=True,
             check=True,
         )
     except subprocess.CalledProcessError as err:
         raise MadoopError(
-            f"Failed executable test: {err}"
-            f"\n{err.stdout.decode()}" if err.stdout else ""
-            f"{err.stderr.decode()}" if err.stderr else ""
+            f"Failed executable test: {err}\n{err.stdout.decode()}"
+            if err.stdout
+            else f"{err.stderr.decode()}"
+            if err.stderr
+            else ""
         ) from err
     except OSError as err:
         raise MadoopError(f"Failed executable test: {err}") from err
@@ -201,7 +202,9 @@ def map_single_chunk(exe, input_path, output_path, chunk):
     """Execute mapper on a single chunk."""
     LOGGER.debug(
         "%s < %s > %s",
-        exe.name, last_two(input_path), last_two(output_path),
+        exe.name,
+        last_two(input_path),
+        last_two(output_path),
     )
     with output_path.open("w") as outfile:
         try:
@@ -211,14 +214,16 @@ def map_single_chunk(exe, input_path, output_path, chunk):
                 check=True,
                 input=chunk,
                 stdout=outfile,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
             )
         except subprocess.CalledProcessError as err:
             raise MadoopError(
                 f"Command returned non-zero: "
                 f"{exe} < {input_path} > {output_path}\n"
                 f"{err}"
-                f"\n{err.stderr.decode()}" if err.stderr else ""
+                f"\n{err.stderr.decode()}"
+                if err.stderr
+                else ""
             ) from err
         except OSError as err:
             raise MadoopError(f"Command returned non-zero: {err}") from err
@@ -235,14 +240,16 @@ def map_stage(exe, input_dir, output_dir):
     ) as pool:
         for input_path in normalize_input_paths(input_dir):
             for chunk in split_file(input_path, MAX_INPUT_SPLIT_SIZE):
-                output_path = output_dir/part_filename(part_num)
-                futures.append(pool.submit(
-                    map_single_chunk,
-                    exe,
-                    input_path,
-                    output_path,
-                    chunk,
-                ))
+                output_path = output_dir / part_filename(part_num)
+                futures.append(
+                    pool.submit(
+                        map_single_chunk,
+                        exe,
+                        input_path,
+                        output_path,
+                        chunk,
+                    )
+                )
                 part_num += 1
     for future in concurrent.futures.as_completed(futures):
         exception = future.exception()
@@ -267,11 +274,8 @@ def keyhash(key):
 
 
 def partition_keys_default(
-        inpath,
-        outpaths,
-        input_keys_stats,
-        output_keys_stats,
-        num_reducers):
+    inpath, outpaths, input_keys_stats, output_keys_stats, num_reducers
+):
     """Allocate lines of inpath among outpaths using hash of key.
 
     Update the data structures provided by the caller input_keys_stats and
@@ -283,7 +287,7 @@ def partition_keys_default(
     with contextlib.ExitStack() as stack:
         outfiles = [stack.enter_context(p.open("a")) for p in outpaths]
         for line in stack.enter_context(inpath.open()):
-            key = line.partition('\t')[0]
+            key = line.partition("\t")[0]
             input_keys_stats[inpath].add(key)
             reducer_idx = keyhash(key) % num_reducers
             outfiles[reducer_idx].write(line)
@@ -291,7 +295,7 @@ def partition_keys_default(
             output_keys_stats[outpath].add(key)
 
 
-def partition_keys_custom(
+def partition_keys_custom(  # noqa: PLR0913
     inpath,
     outpaths,
     input_keys_stats,
@@ -304,38 +308,36 @@ def partition_keys_custom(
     Update the data structures provided by the caller input_keys_stats and
     output_keys_stats.  Both map a filename to a set of of keys.
     """
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-positional-arguments
-    # pylint: disable=too-many-locals
     assert len(outpaths) == num_reducers
     outparent = outpaths[0].parent
     assert all(i.parent == outparent for i in outpaths)
     with contextlib.ExitStack() as stack:
         outfiles = [stack.enter_context(p.open("a")) for p in outpaths]
-        process = stack.enter_context(subprocess.Popen(
-            [partitioner, str(num_reducers)],
-            stdin=stack.enter_context(inpath.open()),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        ))
-        for line, partition in zip(
-            stack.enter_context(inpath.open()),
-            stack.enter_context(process.stdout)
+        process = stack.enter_context(
+            subprocess.Popen(
+                [partitioner, str(num_reducers)],
+                stdin=stack.enter_context(inpath.open()),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
+        for line, partition_raw in zip(
+            stack.enter_context(inpath.open()), stack.enter_context(process.stdout)
         ):
             try:
-                partition = int(partition)
+                partition = int(partition_raw)
             except ValueError as err:
                 raise MadoopError(
-                     "Partition executable returned non-integer value: "
-                     f"{partition} for line '{line}'."
+                    "Partition executable returned non-integer value: "
+                    f"{partition_raw} for line '{line}'."
                 ) from err
             if not 0 <= partition < num_reducers:
                 raise MadoopError(
-                     "Partition executable returned invalid value: "
-                     f"0 <= {partition} < {num_reducers} for line '{line}'."
+                    "Partition executable returned invalid value: "
+                    f"0 <= {partition} < {num_reducers} for line '{line}'."
                 )
-            key = line.partition('\t')[0]
+            key = line.partition("\t")[0]
             input_keys_stats[inpath].add(key)
             outfiles[partition].write(line)
             outpath = outpaths[partition]
@@ -365,8 +367,7 @@ def log_output_key_stats(output_keys_stats, output_dir):
     for outpath, keys in sorted(output_keys_stats.items()):
         all_output_keys.update(keys)
         LOGGER.debug("%s unique_keys=%s", last_two(outpath), len(keys))
-    LOGGER.debug("%s all_unique_keys=%s", output_dir.name,
-                 len(all_output_keys))
+    LOGGER.debug("%s all_unique_keys=%s", output_dir.name, len(all_output_keys))
 
 
 def group_stage(input_dir, output_dir, num_reducers, partitioner):
@@ -380,7 +381,7 @@ def group_stage(input_dir, output_dir, num_reducers, partitioner):
     LOGGER.debug("%s reducers", num_reducers)
     outpaths = []
     for i in range(num_reducers):
-        outpaths.append(output_dir/part_filename(i))
+        outpaths.append(output_dir / part_filename(i))
 
     # Track keyspace stats, map filename -> set of keys
     input_keys_stats = collections.defaultdict(set)
@@ -389,11 +390,18 @@ def group_stage(input_dir, output_dir, num_reducers, partitioner):
     # Partition input, appending to output files
     for inpath in sorted(input_dir.iterdir()):
         if not partitioner:
-            partition_keys_default(inpath, outpaths, input_keys_stats,
-                                   output_keys_stats, num_reducers)
+            partition_keys_default(
+                inpath, outpaths, input_keys_stats, output_keys_stats, num_reducers
+            )
         else:
-            partition_keys_custom(inpath, outpaths, input_keys_stats,
-                                  output_keys_stats, num_reducers, partitioner)
+            partition_keys_custom(
+                inpath,
+                outpaths,
+                input_keys_stats,
+                output_keys_stats,
+                num_reducers,
+                partitioner,
+            )
 
     log_input_key_stats(input_keys_stats, input_dir)
 
@@ -403,7 +411,9 @@ def group_stage(input_dir, output_dir, num_reducers, partitioner):
     for inpath in sorted(input_keys_stats.keys()):
         LOGGER.debug(
             "partition %s >> %s/{%s}",
-            last_two(inpath), outparent.name, ",".join(outnames),
+            last_two(inpath),
+            outparent.name,
+            ",".join(outnames),
         )
 
     # Remove empty output files.  We won't always use the maximum number of
@@ -418,7 +428,6 @@ def group_stage(input_dir, output_dir, num_reducers, partitioner):
         # Don't use a with statement here, because Coverage won't be able to
         # detect code running in a subprocess if we do.
         # https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
-        # pylint: disable=consider-using-with
         pool = multiprocessing.Pool(processes=multiprocessing.cpu_count())
         pool.map(sort_file, sorted(output_dir.iterdir()))
     finally:
@@ -432,7 +441,9 @@ def reduce_single_file(exe, input_path, output_path):
     """Execute reducer on a single file."""
     LOGGER.debug(
         "%s < %s > %s",
-        exe.name, last_two(input_path), last_two(output_path),
+        exe.name,
+        last_two(input_path),
+        last_two(output_path),
     )
     with input_path.open() as infile, output_path.open("w") as outfile:
         try:
@@ -442,14 +453,16 @@ def reduce_single_file(exe, input_path, output_path):
                 check=True,
                 stdin=infile,
                 stdout=outfile,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
             )
         except subprocess.CalledProcessError as err:
             raise MadoopError(
                 f"Command returned non-zero: "
                 f"{exe} < {input_path} > {output_path}\n"
                 f"{err}"
-                f"\n{err.stderr.decode()}" if err.stderr else ""
+                f"\n{err.stderr.decode()}"
+                if err.stderr
+                else ""
             ) from err
         except OSError as err:
             raise MadoopError(f"Command returned non-zero: {err}") from err
@@ -465,18 +478,20 @@ def reduce_stage(exe, input_dir, output_dir):
         max_workers=multiprocessing.cpu_count()
     ) as pool:
         for i, input_path in enumerate(sorted(input_dir.iterdir())):
-            output_path = output_dir/part_filename(i)
-            futures.append(pool.submit(
-                reduce_single_file,
-                exe,
-                input_path,
-                output_path,
-            ))
+            output_path = output_dir / part_filename(i)
+            futures.append(
+                pool.submit(
+                    reduce_single_file,
+                    exe,
+                    input_path,
+                    output_path,
+                )
+            )
     for future in concurrent.futures.as_completed(futures):
         exception = future.exception()
         if exception:
             raise exception
-    LOGGER.info("Finished reduce executions: %s", i+1)
+    LOGGER.info("Finished reduce executions: %s", i + 1)
 
 
 def last_two(path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,9 @@ madoop = "madoop.__main__:main"
 dev = [
     "build",
     "check-manifest",
-    "pycodestyle",
-    "pydocstyle",
-    "pylint",
     "pytest",
     "pytest-cov",
+    "ruff",
     "tox",
     "twine",
 ]
@@ -47,3 +45,51 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["madoop*"]
+
+[tool.ruff.lint]
+# Specify which groups of lint rules to use.
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "D",   # pydocstyle
+    "I",   # isort
+    "UP",  # pyupgrade
+    "N",   # pep8-naming
+    "PT",  # flake8-pytest-style
+    "B",   # flake8-bugbear
+    "SIM", # flake8-simplify
+    "PL",  # pylint subset
+    "RET", # flake8-return
+    "C4",  # flake8-comprehensions
+    "ARG", # flake8-unused-arguments
+]
+# Ignore specific rule violations.  See https://docs.astral.sh/ruff/rules.
+ignore = [
+    # Disable the following two rules because they conflict with other rules.
+    "D203",  # one-blank-line-before-class (conflicts with D211)
+    "D213",  # multi-line-summary-second-line (conflicts with D212)
+
+    # Disable the following rules because they're made redundant by the formatter.
+    "W191",  # tab-indentation
+    "E111",  # indentation-with-invalid-multiple
+    "E114",  # indentation-with-invalid-multiple-comment
+    "E117",  # over-indented
+    "D206",  # indent-with-spaces
+    "D300",  # triple-single-quotes
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.lint.isort]
+# `utils` is the shared test-helper module (tests/utils.py).  Pin it as
+# first-party so it's grouped separately from third-party imports like
+# pytest, instead of relying on ruff's implicit detection.
+known-first-party = ["utils"]
+
+[tool.ruff.lint.per-file-ignores]
+# Plain numeric literals in test assertions are idiomatic, not a code smell.
+# Ignore PLR2004 in test files.
+"test_*.py" = ["PLR2004"]
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-"""
-Dummy file needed for pylint to discover unit tests.
-
-Andrew DeOrio <awdeorio@umich.edu>
-"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,26 +1,29 @@
 """System tests for the API interface."""
+
 from pathlib import Path
+
 import pytest
+
 import madoop
+import utils
 from madoop.mapreduce import map_stage, reduce_stage
-from . import utils
-from .utils import TESTDATA_DIR
+from utils import TESTDATA_DIR
 
 
 def test_simple(tmpdir):
     """Run a simple MapReduce job and verify the output."""
     with tmpdir.as_cwd():
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
             partitioner=None,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output",
+        tmpdir / "output",
     )
 
 
@@ -28,16 +31,16 @@ def test_2_reducers(tmpdir):
     """Run a simple MapReduce job with 2 reducers."""
     with tmpdir.as_cwd():
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=2,
             partitioner=None,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output-2-reducers",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output-2-reducers",
+        tmpdir / "output",
     )
 
 
@@ -45,16 +48,16 @@ def test_bash_executable(tmpdir):
     """Run a MapReduce job written in Bash."""
     with tmpdir.as_cwd():
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.sh",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.sh",
+            map_exe=TESTDATA_DIR / "word_count/map.sh",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.sh",
             num_reducers=4,
             partitioner=None,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output",
+        tmpdir / "output",
     )
 
 
@@ -62,10 +65,10 @@ def test_output_already_exists(tmpdir):
     """Output already existing should raise an error."""
     with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir=tmpdir,
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=2,
         )
 
@@ -74,10 +77,10 @@ def test_bad_map_exe(tmpdir):
     """Map exe returns non-zero should produce an error message."""
     with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map_invalid.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map_invalid.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
             partitioner=None,
         )
@@ -87,12 +90,12 @@ def test_bad_partition_exe(tmpdir):
     """Partition exe returns non-zero should produce an error message."""
     with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
-            partitioner=TESTDATA_DIR/"word_count/partition_invalid.py",
+            partitioner=TESTDATA_DIR / "word_count/partition_invalid.py",
         )
 
 
@@ -100,18 +103,18 @@ def test_noninteger_partition_exe(tmpdir):
     """Partition exe prints non-integer should produce an error message."""
     with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
-            partitioner=TESTDATA_DIR/"word_count/partition_noninteger.py",
+            partitioner=TESTDATA_DIR / "word_count/partition_noninteger.py",
         )
 
     with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
         map_stage(
-            exe=TESTDATA_DIR/"word_count/map_invalid.py",
-            input_dir=TESTDATA_DIR/"word_count/input",
+            exe=TESTDATA_DIR / "word_count/map_invalid.py",
+            input_dir=TESTDATA_DIR / "word_count/input",
             output_dir=Path(tmpdir),
         )
 
@@ -120,8 +123,8 @@ def test_bad_reduce_exe(tmpdir):
     """Reduce exe returns non-zero should produce an error message."""
     with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
         reduce_stage(
-            exe=TESTDATA_DIR/"word_count/reduce_exit_1.py",
-            input_dir=TESTDATA_DIR/"word_count/input",
+            exe=TESTDATA_DIR / "word_count/reduce_exit_1.py",
+            input_dir=TESTDATA_DIR / "word_count/input",
             output_dir=Path(tmpdir),
         )
 
@@ -130,10 +133,10 @@ def test_missing_shebang(tmpdir):
     """Reduce exe with a bad shebag should produce an error message."""
     with tmpdir.as_cwd(), pytest.raises(madoop.MadoopError):
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce_invalid.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce_invalid.py",
             num_reducers=4,
             partitioner=None,
         )
@@ -143,16 +146,16 @@ def test_empty_inputs(tmpdir):
     """Empty input files should not raise an error."""
     with tmpdir.as_cwd():
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input_empty",
+            input_path=TESTDATA_DIR / "word_count/input_empty",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
             partitioner=None,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output",
+        tmpdir / "output",
     )
 
 
@@ -160,112 +163,117 @@ def test_single_input_file(tmpdir):
     """Run a simple MapReduce job with an input file instead of dir."""
     with tmpdir.as_cwd():
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input-single-file.txt",
+            input_path=TESTDATA_DIR / "word_count/input-single-file.txt",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
             partitioner=None,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output",
+        tmpdir / "output",
     )
 
 
 def test_ignores_subdirs(tmpdir):
-    """Run a simple MapReduce job with an input directory containing a
-    subdirectory. The subdirectory should be gracefully ignored.
+    """Run a simple MapReduce job with an input directory containing a subdirectory.
+
+    The subdirectory should be gracefully ignored.
     """
     with tmpdir.as_cwd():
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input_with_subdir",
+            input_path=TESTDATA_DIR / "word_count/input_with_subdir",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
             partitioner=None,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output",
+        tmpdir / "output",
     )
 
 
 def test_input_path_spaces(tmpdir):
-    """Run a simple MapReduce job with an input directory containing a
-    subdirectory. The subdirectory should be gracefully ignored.
+    """Run a simple MapReduce job with an input directory containing a subdirectory.
+
+    The subdirectory should be gracefully ignored.
     """
     with tmpdir.as_cwd():
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count SPACE/input SPACE",
+            input_path=TESTDATA_DIR / "word_count SPACE/input SPACE",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count SPACE/map SPACE.py",
-            reduce_exe=TESTDATA_DIR/"word_count SPACE/reduce SPACE.py",
-            num_reducers=4
+            map_exe=TESTDATA_DIR / "word_count SPACE/map SPACE.py",
+            reduce_exe=TESTDATA_DIR / "word_count SPACE/reduce SPACE.py",
+            num_reducers=4,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output",
+        tmpdir / "output",
     )
 
 
 def test_map_exe_error_msg(tmpdir):
-    """Map exe returns non-zero with stderr output should produce an
-    error message and forward the stderr output.
+    """Map exe returns non-zero with stderr output should produce an error message.
+
+    The stderr output should be forwarded.
     """
-    with tmpdir.as_cwd(), pytest.raises(
-        madoop.MadoopError,
-        match="Map error message to stderr"
+    with (
+        tmpdir.as_cwd(),
+        pytest.raises(madoop.MadoopError, match="Map error message to stderr"),
     ):
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map_error_msg.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map_error_msg.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
             partitioner=None,
         )
 
-    with tmpdir.as_cwd(), pytest.raises(
-        madoop.MadoopError,
-        match="Map error message to stderr"
+    with (
+        tmpdir.as_cwd(),
+        pytest.raises(madoop.MadoopError, match="Map error message to stderr"),
     ):
         map_stage(
-            exe=TESTDATA_DIR/"word_count/map_error_msg.py",
-            input_dir=TESTDATA_DIR/"word_count/input",
+            exe=TESTDATA_DIR / "word_count/map_error_msg.py",
+            input_dir=TESTDATA_DIR / "word_count/input",
             output_dir=Path(tmpdir),
         )
 
 
 def test_partition_exe_error_msg(tmpdir):
-    """Partition exe returns non-zero with stderr output should produce an
-    error message and forward the stderr output.
+    """Partition exe returns non-zero with stderr output should produce an error.
+
+    The stderr output should be forwarded.
     """
-    with tmpdir.as_cwd(), pytest.raises(
-        madoop.MadoopError,
-        match="Partition error message to stderr"
+    with (
+        tmpdir.as_cwd(),
+        pytest.raises(madoop.MadoopError, match="Partition error message to stderr"),
     ):
         madoop.mapreduce(
-            input_path=TESTDATA_DIR/"word_count/input",
+            input_path=TESTDATA_DIR / "word_count/input",
             output_dir="output",
-            map_exe=TESTDATA_DIR/"word_count/map.py",
-            reduce_exe=TESTDATA_DIR/"word_count/reduce.py",
+            map_exe=TESTDATA_DIR / "word_count/map.py",
+            reduce_exe=TESTDATA_DIR / "word_count/reduce.py",
             num_reducers=4,
-            partitioner=TESTDATA_DIR/"word_count/partition_error_msg.py",
+            partitioner=TESTDATA_DIR / "word_count/partition_error_msg.py",
         )
 
 
 def test_reduce_exe_error_msg(tmpdir):
-    """Reduce exe returns non-zero with stderr output should produce an
-    error message and forward the stderr output.
+    """Reduce exe returns non-zero with stderr output should produce an error message.
+
+    The stderr output should be forwarded.
     """
-    with tmpdir.as_cwd(), pytest.raises(
-        madoop.MadoopError,
-        match="Reduce error message to stderr"
+    with (
+        tmpdir.as_cwd(),
+        pytest.raises(madoop.MadoopError, match="Reduce error message to stderr"),
     ):
         reduce_stage(
-            exe=TESTDATA_DIR/"word_count/reduce_error_msg.py",
-            input_dir=TESTDATA_DIR/"word_count/input",
+            exe=TESTDATA_DIR / "word_count/reduce_error_msg.py",
+            input_dir=TESTDATA_DIR / "word_count/input",
             output_dir=Path(tmpdir),
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,12 @@
 """System tests for the command line interface."""
-import subprocess
+
 import importlib.metadata
+import subprocess
+
 import pytest
-from . import utils
-from .utils import TESTDATA_DIR
+
+import utils
+from utils import TESTDATA_DIR
 
 
 def test_version():
@@ -35,17 +38,21 @@ def test_simple(tmpdir):
         subprocess.run(
             [
                 "madoop",
-                "-input", TESTDATA_DIR/"word_count/input",
-                "-output", "output",
-                "-mapper", TESTDATA_DIR/"word_count/map.py",
-                "-reducer", TESTDATA_DIR/"word_count/reduce.py",
+                "-input",
+                TESTDATA_DIR / "word_count/input",
+                "-output",
+                "output",
+                "-mapper",
+                TESTDATA_DIR / "word_count/map.py",
+                "-reducer",
+                TESTDATA_DIR / "word_count/reduce.py",
             ],
             stdout=subprocess.PIPE,
             check=True,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output",
+        tmpdir / "output",
     )
 
 
@@ -55,18 +62,23 @@ def test_2_reducers(tmpdir):
         subprocess.run(
             [
                 "madoop",
-                "-input", TESTDATA_DIR/"word_count/input",
-                "-output", "output",
-                "-mapper", TESTDATA_DIR/"word_count/map.py",
-                "-reducer", TESTDATA_DIR/"word_count/reduce.py",
-                "-numReduceTasks", "2",
+                "-input",
+                TESTDATA_DIR / "word_count/input",
+                "-output",
+                "output",
+                "-mapper",
+                TESTDATA_DIR / "word_count/map.py",
+                "-reducer",
+                TESTDATA_DIR / "word_count/reduce.py",
+                "-numReduceTasks",
+                "2",
             ],
             stdout=subprocess.PIPE,
             check=True,
         )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/output-2-reducers",
-        tmpdir/"output",
+        TESTDATA_DIR / "word_count/correct/output-2-reducers",
+        tmpdir / "output",
     )
 
 
@@ -77,13 +89,17 @@ def test_verbose(tmpdir):
             [
                 "madoop",
                 "--verbose",
-                "-input", TESTDATA_DIR/"word_count/input",
-                "-output", "output",
-                "-mapper", TESTDATA_DIR/"word_count/map.py",
-                "-reducer", TESTDATA_DIR/"word_count/reduce.py",
+                "-input",
+                TESTDATA_DIR / "word_count/input",
+                "-output",
+                "output",
+                "-mapper",
+                TESTDATA_DIR / "word_count/map.py",
+                "-reducer",
+                TESTDATA_DIR / "word_count/reduce.py",
             ],
             stdout=subprocess.PIPE,
-            universal_newlines=True,
+            text=True,
             check=True,
         )
     stdout_lines = completed_process.stdout.strip().split("\n")
@@ -98,11 +114,16 @@ def test_hadoop_arguments(tmpdir):
         subprocess.run(
             [
                 "madoop",
-                "jar", "hadoop-streaming-2.7.2.jar",  # Hadoop args
-                "-input", TESTDATA_DIR/"word_count/input",
-                "-output", "output",
-                "-mapper", TESTDATA_DIR/"word_count/map.py",
-                "-reducer", TESTDATA_DIR/"word_count/reduce.py",
+                "jar",
+                "hadoop-streaming-2.7.2.jar",  # Hadoop args
+                "-input",
+                TESTDATA_DIR / "word_count/input",
+                "-output",
+                "output",
+                "-mapper",
+                TESTDATA_DIR / "word_count/map.py",
+                "-reducer",
+                TESTDATA_DIR / "word_count/reduce.py",
             ],
             stdout=subprocess.PIPE,
             check=True,
@@ -115,19 +136,17 @@ def test_example(tmpdir):
         subprocess.run(
             ["madoop", "--example"],
             check=True,
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
+            capture_output=True,
         )
-    assert (tmpdir/"example/input/input01.txt").exists()
-    assert (tmpdir/"example/input/input02.txt").exists()
-    assert (tmpdir/"example/map.py").exists()
-    assert (tmpdir/"example/reduce.py").exists()
+    assert (tmpdir / "example/input/input01.txt").exists()
+    assert (tmpdir / "example/input/input02.txt").exists()
+    assert (tmpdir / "example/map.py").exists()
+    assert (tmpdir / "example/reduce.py").exists()
 
     # Call it again and it should refuse to clobber
     with tmpdir.as_cwd(), pytest.raises(subprocess.CalledProcessError):
         subprocess.run(
             ["madoop", "--example"],
             check=True,
-            stderr=subprocess.PIPE,
-            stdout=subprocess.PIPE,
+            capture_output=True,
         )

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -1,26 +1,28 @@
 """System tests for the map stage of Michigan Hadoop."""
+
 import shutil
 from pathlib import Path
+
+import utils
 from madoop.mapreduce import (
-    map_stage,
+    MAX_INPUT_SPLIT_SIZE,
     group_stage,
+    map_stage,
     reduce_stage,
     split_file,
-    MAX_INPUT_SPLIT_SIZE,
 )
-from . import utils
-from .utils import TESTDATA_DIR
+from utils import TESTDATA_DIR
 
 
 def test_map_stage(tmpdir):
     """Test the map stage using word count example."""
     map_stage(
-        exe=TESTDATA_DIR/"word_count/map.py",
-        input_dir=TESTDATA_DIR/"word_count/input",
+        exe=TESTDATA_DIR / "word_count/map.py",
+        input_dir=TESTDATA_DIR / "word_count/input",
         output_dir=Path(tmpdir),
     )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/mapper-output",
+        TESTDATA_DIR / "word_count/correct/mapper-output",
         tmpdir,
     )
 
@@ -28,13 +30,13 @@ def test_map_stage(tmpdir):
 def test_group_stage(tmpdir):
     """Test group stage using word count example."""
     group_stage(
-        input_dir=TESTDATA_DIR/"word_count/correct/mapper-output",
+        input_dir=TESTDATA_DIR / "word_count/correct/mapper-output",
         output_dir=Path(tmpdir),
         num_reducers=4,
         partitioner=None,
     )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/grouper-output",
+        TESTDATA_DIR / "word_count/correct/grouper-output",
         tmpdir,
     )
 
@@ -42,13 +44,13 @@ def test_group_stage(tmpdir):
 def test_group_stage_2_reducers(tmpdir):
     """Test group stage using word count example with 2 reducers."""
     group_stage(
-        input_dir=TESTDATA_DIR/"word_count/correct/mapper-output",
+        input_dir=TESTDATA_DIR / "word_count/correct/mapper-output",
         output_dir=Path(tmpdir),
         num_reducers=2,
         partitioner=None,
     )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/grouper-output-2-reducers",
+        TESTDATA_DIR / "word_count/correct/grouper-output-2-reducers",
         tmpdir,
     )
 
@@ -56,13 +58,13 @@ def test_group_stage_2_reducers(tmpdir):
 def test_group_stage_custom_partitioner(tmpdir):
     """Test group stage using word count example with custom partitioner."""
     group_stage(
-        input_dir=TESTDATA_DIR/"word_count/correct/mapper-output",
+        input_dir=TESTDATA_DIR / "word_count/correct/mapper-output",
         output_dir=Path(tmpdir),
         num_reducers=2,
-        partitioner=TESTDATA_DIR/"word_count/partition.py",
+        partitioner=TESTDATA_DIR / "word_count/partition.py",
     )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/grouper-output-custom-partitioner",
+        TESTDATA_DIR / "word_count/correct/grouper-output-custom-partitioner",
         tmpdir,
     )
 
@@ -70,12 +72,12 @@ def test_group_stage_custom_partitioner(tmpdir):
 def test_reduce_stage(tmpdir):
     """Test reduce stage using word count example."""
     reduce_stage(
-        exe=TESTDATA_DIR/"word_count/reduce.py",
-        input_dir=TESTDATA_DIR/"word_count/correct/grouper-output",
+        exe=TESTDATA_DIR / "word_count/reduce.py",
+        input_dir=TESTDATA_DIR / "word_count/correct/grouper-output",
         output_dir=Path(tmpdir),
     )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/reducer-output",
+        TESTDATA_DIR / "word_count/correct/reducer-output",
         tmpdir,
     )
 
@@ -83,26 +85,27 @@ def test_reduce_stage(tmpdir):
 def test_reduce_stage_2_reducers(tmpdir):
     """Test reduce stage using word count example with 2 reducers."""
     reduce_stage(
-        exe=TESTDATA_DIR/"word_count/reduce.py",
-        input_dir=TESTDATA_DIR/"word_count/correct/grouper-output-2-reducers",
+        exe=TESTDATA_DIR / "word_count/reduce.py",
+        input_dir=TESTDATA_DIR / "word_count/correct/grouper-output-2-reducers",
         output_dir=Path(tmpdir),
     )
     utils.assert_dirs_eq(
-        TESTDATA_DIR/"word_count/correct/reducer-output-2-reducers",
+        TESTDATA_DIR / "word_count/correct/reducer-output-2-reducers",
         tmpdir,
     )
 
 
 def test_input_splitting(tmp_path):
     """Test that the Map Stage correctly splits input."""
-    input_data = "o" * (MAX_INPUT_SPLIT_SIZE - 10) + "\n" + \
-        "a" * int(MAX_INPUT_SPLIT_SIZE / 2)
-    input_dir = tmp_path/"input"
-    output_dir = tmp_path/"output"
+    input_data = (
+        "o" * (MAX_INPUT_SPLIT_SIZE - 10) + "\n" + "a" * int(MAX_INPUT_SPLIT_SIZE / 2)
+    )
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
     input_dir.mkdir()
     output_dir.mkdir()
 
-    with open(input_dir/"input.txt", "w", encoding="utf-8") as input_file:
+    with open(input_dir / "input.txt", "w", encoding="utf-8") as input_file:
         input_file.write(input_data)
 
     map_stage(
@@ -113,12 +116,12 @@ def test_input_splitting(tmp_path):
 
     output_files = sorted(output_dir.glob("*"))
     assert len(output_files) == 2
-    assert output_files == [output_dir/"part-00000", output_dir/"part-00001"]
+    assert output_files == [output_dir / "part-00000", output_dir / "part-00001"]
 
-    with open(output_dir/"part-00000", "r", encoding="utf-8") as outfile1:
+    with open(output_dir / "part-00000", encoding="utf-8") as outfile1:
         data = outfile1.read()
         assert data == "o" * (MAX_INPUT_SPLIT_SIZE - 10) + "\n"
-    with open(output_dir/"part-00001", "r", encoding="utf-8") as outfile2:
+    with open(output_dir / "part-00001", encoding="utf-8") as outfile2:
         data = outfile2.read()
         assert data == "a" * int(MAX_INPUT_SPLIT_SIZE / 2)
 
@@ -126,7 +129,7 @@ def test_input_splitting(tmp_path):
 def test_split_file_mid_chunk(tmp_path):
     """Test that file splitting still works when data remains in the buffer."""
     input_data = "noah says\nhello world"
-    input_file = tmp_path/"input.txt"
+    input_file = tmp_path / "input.txt"
     with open(input_file, "w", encoding="utf-8") as infile:
         infile.write(input_data)
 

--- a/tests/testdata/word_count SPACE/map SPACE.py
+++ b/tests/testdata/word_count SPACE/map SPACE.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Word count mapper."""
-import sys
 
+import sys
 
 for line in sys.stdin:
     words = line.split()

--- a/tests/testdata/word_count SPACE/reduce SPACE.py
+++ b/tests/testdata/word_count SPACE/reduce SPACE.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Word count reducer."""
-import sys
+
 import itertools
+import sys
 
 
 def main():

--- a/tests/testdata/word_count/map.py
+++ b/tests/testdata/word_count/map.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Word count mapper."""
-import sys
 
+import sys
 
 for line in sys.stdin:
     words = line.split()

--- a/tests/testdata/word_count/map_error_msg.py
+++ b/tests/testdata/word_count/map_error_msg.py
@@ -3,7 +3,6 @@
 
 import sys
 
-
 # Avoid error on executable check which has an empty string input
 input_lines_n = sum(1 for _ in sys.stdin)
 if input_lines_n > 1:

--- a/tests/testdata/word_count/partition.py
+++ b/tests/testdata/word_count/partition.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S python3 -u
 """Word count partitioner."""
-import sys
 
+import sys
 
 num_reducers = int(sys.argv[1])
 

--- a/tests/testdata/word_count/reduce.py
+++ b/tests/testdata/word_count/reduce.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Word count reducer."""
-import sys
+
 import itertools
+import sys
 
 
 def main():

--- a/tests/testdata/word_count/reduce_error_msg.py
+++ b/tests/testdata/word_count/reduce_error_msg.py
@@ -3,7 +3,6 @@
 
 import sys
 
-
 # Avoid error on executable check which has an empty string input
 input_lines_n = sum(1 for _ in sys.stdin)
 if input_lines_n > 1:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,18 +1,16 @@
 """Unit test utilities."""
+
 import filecmp
 import pathlib
 
-
 # Directory containing unit test input files, etc.
-TESTDATA_DIR = pathlib.Path(__file__).parent/"testdata"
+TESTDATA_DIR = pathlib.Path(__file__).parent / "testdata"
 
 
 def assert_dirs_eq(dir1, dir2):
     """Compare two directories of files."""
     assert dir1 != dir2, (
-        "Refusing to compare a directory to itself:\n"
-        f"dir1 = {dir1}\n"
-        f"dir2 = {dir2}\n"
+        f"Refusing to compare a directory to itself:\ndir1 = {dir1}\ndir2 = {dir2}\n"
     )
 
     # Get a list of files in each directory
@@ -37,7 +35,5 @@ def assert_dirs_eq(dir1, dir2):
     # Compare files pairwise
     for path1, path2 in zip(sorted(paths1), sorted(paths2)):
         assert filecmp.cmp(path1, path2, shallow=False), (
-            "Files do not match:\n"
-            f"path1 = {path1}\n"
-            f"path2 = {path2}\n"
+            f"Files do not match:\npath1 = {path1}\npath2 = {path2}\n"
         )

--- a/tox.ini
+++ b/tox.ini
@@ -5,20 +5,17 @@
 envlist = py3
 
 # Run unit tests
-# HACK: Pydocstyle fails to find tests.  Invoke a shell to use a glob.
 [testenv]
 setenv =
   PYTHONPATH = {toxinidir}
 allowlist_externals =
-  sh
   diff
 extras = dev
 commands =
   diff -r madoop/example/input tests/testdata/word_count/input/
   diff -r madoop/example/map.py tests/testdata/word_count/map.py
   diff -r madoop/example/reduce.py tests/testdata/word_count/reduce.py
-  pycodestyle madoop tests
-  sh -c "pydocstyle madoop tests/*"
-  pylint madoop tests
+  ruff check madoop tests
+  ruff format --check madoop tests
   check-manifest
   pytest -vvs --cov madoop


### PR DESCRIPTION
Important note: this PR merges to develop, so it has no effect on current SU26 term.  Also, it's tooling only (not user-facing).

## Summary
- Replace pylint, pycodestyle, and pydocstyle with a single ruff config for both linting (`ruff check`) and formatting (`ruff format`), matching the convention already used in the p1/p2/p3 chat485 projects.
- Drop `tests/__init__.py` and switch test modules to flat imports (`import utils`) instead of relative imports (`from . import utils`), since ruff/pytest no longer need `tests/` to be a package.
- Reformat the codebase with `ruff format` and resolve the handful of new lint findings this surfaced (shadowed loop/context variables, `subprocess.run` simplified to `capture_output=True`, docstring formatting, explicit re-export aliases in `madoop/__init__.py`).

## Test plan
- [x] `tox -e py3` passes (file diffs, ruff check, ruff format --check, check-manifest, pytest with coverage)
- [x] `ruff check madoop tests` and `ruff format --check madoop tests` pass standalone
- [x] `pytest` passes (31 tests)