### PR TITLE
Fix Python version in CI like agio

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       # Define OS and Python versions to use.
       matrix:
-        python-version: ["3.9", "3.x"]  # floor and latest minor version
+        python-version: ["3.x"]  # always the latest Python; no version bump needed
         os: [ubuntu-latest]
 
     # Sequence of tasks for this job

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,6 @@ exception type that escapes the API; the CLI catches it and exits with `Error: .
   ignored `jar hadoop-streaming-X.Y.Z.jar` argument is tolerated.
 - The package version lives in `pyproject.toml`; the release procedure (tag, build,
   twine) is in `CONTRIBUTING.md`.
-- **Supported Python versions live in two places that must stay in lock step.** When
-  adding or dropping a version, update both together:
-  1. `pyproject.toml` `requires-python` (the minimum version floor).
-  2. `.github/workflows/continuous_integration.yml` `python-version` matrix (tests the
-     floor and the latest minor, e.g. `["3.9", "3.x"]`).
+- **Python version support is zero-maintenance.** `pyproject.toml` sets the minimum
+  floor via `requires-python`; CI only ever tests the latest Python (`.github/workflows/continuous_integration.yml`
+  matrix is `["3.x"]`), so no file needs editing when a new Python is released.

--- a/madoop/mapreduce.py
+++ b/madoop/mapreduce.py
@@ -322,7 +322,10 @@ def partition_keys_custom(  # noqa: PLR0913
                 text=True,
             )
         )
-        for line, partition_raw in zip(
+        # Don't use strict=True: a failing partitioner exits early without writing to
+        # stdout, which must fall through to the return code check below instead of
+        # raising here.
+        for line, partition_raw in zip(  # noqa: B905
             stack.enter_context(inpath.open()), stack.enter_context(process.stdout)
         ):
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 keywords = [
   "madoop", "Hadoop", "MapReduce", "Michigan Hadoop", "Hadoop Streaming"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Education",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,7 +33,7 @@ def assert_dirs_eq(dir1, dir2):
     )
 
     # Compare files pairwise
-    for path1, path2 in zip(sorted(paths1), sorted(paths2)):
+    for path1, path2 in zip(sorted(paths1), sorted(paths2), strict=True):
         assert filecmp.cmp(path1, path2, shallow=False), (
             f"Files do not match:\npath1 = {path1}\npath2 = {path2}\n"
         )


### PR DESCRIPTION
## Python versions and CI

- `requires-python = ">=3.10"`, matching the floor used in `agio`.
- Zero-maintenance CI version handling: the matrix runs `["3.x"]` (always the latest Python), so no file needs editing when a new Python is released.
- Update `AGENTS.md` to describe the new zero-maintenance scheme instead of the old "two places must stay in lock step" note.

See eecs485staff/agio-cli#46 for the same change applied there.

## Dependency-drift fix

Bumping the floor to 3.10 changed ruff's inferred target version, surfacing two `B905` findings (`zip()` without an explicit `strict=`):

- `tests/utils.py`: add `strict=True`; the two lists are already asserted equal length just above, so this is safe and just makes the invariant explicit.
- `madoop/mapreduce.py`: left non-strict with a `noqa` and a comment. A failing partitioner subprocess exits early without writing to stdout, and the code depends on that length mismatch falling through to the return-code check below so it can raise the correct error; `strict=True` would raise `ValueError` before that check runs.